### PR TITLE
WebSocketHandler からクロージャの型パラメータを削除する

### DIFF
--- a/src/exchanges/binance.rs
+++ b/src/exchanges/binance.rs
@@ -349,7 +349,7 @@ impl Default for BinanceOptions {
     }
 }
 
-impl<'a, R: DeserializeOwned + 'a> HttpOption<'a, R> for BinanceOption {
+impl<'a, R: DeserializeOwned + 'a, B> HttpOption<'a, R, B> for BinanceOption where B: Serialize {
     type RequestHandler = BinanceRequestHandler<'a, R>;
 
     #[inline(always)]

--- a/src/exchanges/binance.rs
+++ b/src/exchanges/binance.rs
@@ -146,8 +146,8 @@ pub struct BinanceRequestHandler<'a, R: DeserializeOwned> {
 }
 
 /// A `struct` that implements [WebSocketHandler]
-pub struct BinanceWebSocketHandler<H: FnMut(serde_json::Value) + Send + 'static> {
-    message_handler: H,
+pub struct BinanceWebSocketHandler {
+    message_handler: Box<dyn FnMut(serde_json::Value) + Send>,
     options: BinanceOptions,
 }
 
@@ -247,7 +247,7 @@ where
     }
 }
 
-impl<H> WebSocketHandler for BinanceWebSocketHandler<H> where H: FnMut(serde_json::Value) + Send + 'static, {
+impl WebSocketHandler for BinanceWebSocketHandler {
     fn websocket_config(&self) -> WebSocketConfig {
         let mut config = self.options.websocket_config.clone();
         if self.options.websocket_url != BinanceWebSocketUrl::None {
@@ -362,12 +362,12 @@ impl<'a, R: DeserializeOwned + 'a, B> HttpOption<'a, R, B> for BinanceOption whe
 }
 
 impl<H: FnMut(serde_json::Value) + Send + 'static> WebSocketOption<H> for BinanceOption {
-    type WebSocketHandler = BinanceWebSocketHandler<H>;
+    type WebSocketHandler = BinanceWebSocketHandler;
 
     #[inline(always)]
     fn websocket_handler(handler: H, options: Self::Options) -> Self::WebSocketHandler {
         BinanceWebSocketHandler {
-            message_handler: handler,
+            message_handler: Box::new(handler),
             options,
         }
     }

--- a/src/exchanges/bitflyer.rs
+++ b/src/exchanges/bitflyer.rs
@@ -353,7 +353,7 @@ impl Default for BitFlyerOptions {
     }
 }
 
-impl<'a, R: DeserializeOwned + 'a> HttpOption<'a, R> for BitFlyerOption {
+impl<'a, R: DeserializeOwned + 'a, B> HttpOption<'a, R, B> for BitFlyerOption where B: Serialize {
     type RequestHandler = BitFlyerRequestHandler<'a, R>;
 
     #[inline(always)]

--- a/src/exchanges/bybit.rs
+++ b/src/exchanges/bybit.rs
@@ -493,7 +493,7 @@ impl Default for BybitOptions {
     }
 }
 
-impl<'a, R: DeserializeOwned + 'a> HttpOption<'a, R> for BybitOption {
+impl<'a, R: DeserializeOwned + 'a, B> HttpOption<'a, R, B> for BybitOption where B: Serialize {
     type RequestHandler = BybitRequestHandler<'a, R>;
 
     #[inline(always)]

--- a/src/exchanges/coincheck.rs
+++ b/src/exchanges/coincheck.rs
@@ -95,8 +95,8 @@ pub struct CoincheckRequestHandler<'a, R: DeserializeOwned> {
 }
 
 /// A `struct` that implements [WebSocketHandler]
-pub struct CoincheckWebSocketHandler<H: FnMut(serde_json::Value) + Send + 'static> {
-    message_handler: H,
+pub struct CoincheckWebSocketHandler {
+    message_handler: Box<dyn FnMut(serde_json::Value) + Send>,
     options: CoincheckOptions,
 }
 
@@ -182,7 +182,7 @@ where
     }
 }
 
-impl<H> WebSocketHandler for CoincheckWebSocketHandler<H> where H: FnMut(serde_json::Value) + Send + 'static, {
+impl WebSocketHandler for CoincheckWebSocketHandler {
     fn websocket_config(&self) -> WebSocketConfig {
         let mut config = self.options.websocket_config.clone();
         if self.options.websocket_url != CoincheckWebSocketUrl::None {
@@ -282,12 +282,12 @@ impl<'a, R: DeserializeOwned + 'a, B> HttpOption<'a, R, B> for CoincheckOption w
 }
 
 impl<H: FnMut(serde_json::Value) + Send + 'static> WebSocketOption<H> for CoincheckOption {
-    type WebSocketHandler = CoincheckWebSocketHandler<H>;
+    type WebSocketHandler = CoincheckWebSocketHandler;
 
     #[inline(always)]
     fn websocket_handler(handler: H, options: Self::Options) -> Self::WebSocketHandler {
         CoincheckWebSocketHandler {
-            message_handler: handler,
+            message_handler: Box::new(handler),
             options,
         }
     }

--- a/src/exchanges/coincheck.rs
+++ b/src/exchanges/coincheck.rs
@@ -269,7 +269,7 @@ impl Default for CoincheckOptions {
     }
 }
 
-impl<'a, R: DeserializeOwned + 'a> HttpOption<'a, R> for CoincheckOption {
+impl<'a, R: DeserializeOwned + 'a, B> HttpOption<'a, R, B> for CoincheckOption where B: Serialize {
     type RequestHandler = CoincheckRequestHandler<'a, R>;
 
     #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,10 @@ pub mod traits;
 macro_rules! request_return_type {
     ($lt:lifetime, $Response:ty, $Options:ty,  $Body:ty) => {
         Result<
-            <<$Options as HttpOption<$lt, $Response>>::RequestHandler as RequestHandler<$Body>>::Successful,
+            <<$Options as HttpOption<$lt, $Response, $Body>>::RequestHandler as RequestHandler<$Body>>::Successful,
             RequestError<
-                <<$Options as HttpOption<$lt, $Response>>::RequestHandler as RequestHandler<$Body>>::BuildError,
-                <<$Options as HttpOption<$lt, $Response>>::RequestHandler as RequestHandler<$Body>>::Unsuccessful,
+                <<$Options as HttpOption<$lt, $Response, $Body>>::RequestHandler as RequestHandler<$Body>>::BuildError,
+                <<$Options as HttpOption<$lt, $Response, $Body>>::RequestHandler as RequestHandler<$Body>>::Unsuccessful,
             >,
         >
     };
@@ -68,7 +68,7 @@ impl Client {
     pub async fn request<'a, R, O, Q, B>(&self, method: Method, url: &str, query: Option<&Q>, body: Option<B>, options: impl IntoIterator<Item=O>)
         -> request_return_type!('a, R, O, B)
     where
-        O: HttpOption<'a, R>,
+        O: HttpOption<'a, R, B>,
         O::RequestHandler: RequestHandler<B>,
         Self: GetOptions<O::Options>,
         Q: Serialize + ?Sized,
@@ -80,7 +80,7 @@ impl Client {
     #[inline(always)]
     pub async fn get<'a, R, O, Q>(&self, url: &str, query: Option<&Q>, options: impl IntoIterator<Item=O>) -> request_return_type!('a, R, O, ())
     where
-        O: HttpOption<'a, R>,
+        O: HttpOption<'a, R, ()>,
         O::RequestHandler: RequestHandler<()>,
         Self: GetOptions<O::Options>,
         Q: Serialize + ?Sized,
@@ -92,7 +92,7 @@ impl Client {
     #[inline(always)]
     pub async fn get_no_query<'a, R, O>(&self, url: &str, options: impl IntoIterator<Item=O>) -> request_return_type!('a, R, O, ())
     where
-        O: HttpOption<'a, R>,
+        O: HttpOption<'a, R, ()>,
         O::RequestHandler: RequestHandler<()>,
         Self: GetOptions<O::Options>,
     {
@@ -104,7 +104,7 @@ impl Client {
     pub async fn post<'a, R, O, B>(&self, url: &str, body: Option<B>, options: impl IntoIterator<Item=O>)
         -> request_return_type!('a, R, O, B)
     where
-        O: HttpOption<'a, R>,
+        O: HttpOption<'a, R, B>,
         O::RequestHandler: RequestHandler<B>,
         Self: GetOptions<O::Options>,
     {
@@ -116,7 +116,7 @@ impl Client {
     pub async fn post_no_body<'a, R, O>(&self, url: &str, options: impl IntoIterator<Item=O>)
         -> request_return_type!('a, R, O, ())
     where
-        O: HttpOption<'a, R>,
+        O: HttpOption<'a, R, ()>,
         O::RequestHandler: RequestHandler<()>,
         Self: GetOptions<O::Options>,
     {
@@ -128,7 +128,7 @@ impl Client {
     pub async fn put<'a, R, O, B>(&self, url: &str, body: Option<B>, options: impl IntoIterator<Item=O>)
         -> request_return_type!('a, R, O, B)
     where
-        O: HttpOption<'a, R>,
+        O: HttpOption<'a, R, B>,
         O::RequestHandler: RequestHandler<B>,
         Self: GetOptions<O::Options>,
     {
@@ -140,7 +140,7 @@ impl Client {
     pub async fn put_no_body<'a, R, O>(&self, url: &str, options: impl IntoIterator<Item=O>)
         -> request_return_type!('a, R, O, ())
     where
-        O: HttpOption<'a, R>,
+        O: HttpOption<'a, R, ()>,
         O::RequestHandler: RequestHandler<()>,
         Self: GetOptions<O::Options>,
     {
@@ -151,7 +151,7 @@ impl Client {
     #[inline(always)]
     pub async fn delete<'a, R, O, Q>(&self, url: &str, query: Option<&Q>, options: impl IntoIterator<Item=O>) -> request_return_type!('a, R, O, ())
     where
-        O: HttpOption<'a, R>,
+        O: HttpOption<'a, R, ()>,
         O::RequestHandler: RequestHandler<()>,
         Self: GetOptions<O::Options>,
         Q: Serialize + ?Sized,
@@ -163,7 +163,7 @@ impl Client {
     #[inline(always)]
     pub async fn delete_no_query<'a, R, O>(&self, url: &str, options: impl IntoIterator<Item=O>) -> request_return_type!('a, R, O, ())
     where
-        O: HttpOption<'a, R>,
+        O: HttpOption<'a, R, ()>,
         O::RequestHandler: RequestHandler<()>,
         Self: GetOptions<O::Options>,
     {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use generic_api_client::{http, websocket};
 
 /// A `trait` that represents an option which can be set when creating handlers
 pub trait HandlerOption: Default {
@@ -13,16 +14,16 @@ pub trait HandlerOptions: Default + Clone + Debug {
     fn update(&mut self, option: Self::OptionItem);
 }
 
-/// A `trait` that shows the implementing type is able to create [generic_api_client::http::RequestHandler]s
-pub trait HttpOption<'a, R>: HandlerOption {
-    type RequestHandler;
+/// A `trait` that shows the implementing type is able to create [http::RequestHandler]s
+pub trait HttpOption<'a, R, B>: HandlerOption {
+    type RequestHandler: http::RequestHandler<B>;
 
     fn request_handler(options: Self::Options) -> Self::RequestHandler;
 }
 
-/// A `trait` that shows the implementing type is able to create [generic_api_client::websocket::WebSocketHandler]s
+/// A `trait` that shows the implementing type is able to create [websocket::WebSocketHandler]s
 pub trait WebSocketOption<H>: HandlerOption {
-    type WebSocketHandler;
+    type WebSocketHandler: websocket::WebSocketHandler;
 
     fn websocket_handler(handler: H, options: Self::Options) -> Self::WebSocketHandler;
 }


### PR DESCRIPTION
issue: #17

今までは、`WebSocketConnection` の型が例えば `WebSocketConnection<BinanceWebSocketHandler<H>>` のようになっていて、 `H` がクロージャの型のため構造体のフィールドに入れるのが難しかった。

内部的に `Box<dyn FnMut>` を使うことで、`H` の型パラメータを削除した。